### PR TITLE
fix(commonContent): newsletterLabelCodeText to str

### DIFF
--- a/src/api/common-content/content-types/common-content/schema.json
+++ b/src/api/common-content/content-types/common-content/schema.json
@@ -95,29 +95,17 @@
     "successActionButtonUrl": {
       "pluginOptions": {
         "i18n": {
-          "localized": false
+          "localized": true
         }
       },
       "type": "string",
       "required": true,
       "regex": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-/]))?$"
     },
-    "newsletterLabelTextCode": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "customField",
-      "options": [
-        "snp"
-      ],
-      "customField": "plugin::multi-select.multi-select"
-    },
     "newsletterSlug": {
       "pluginOptions": {
         "i18n": {
-          "localized": true
+          "localized": false
         }
       },
       "type": "customField",
@@ -128,6 +116,15 @@
         "security-privacy-news"
       ],
       "customField": "plugin::multi-select.multi-select"
+    },
+    "newsletterLabelTextCode": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "string",
+      "regex": "\\b(mozilla|snp|hubs|mdnplus)\\b"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -901,13 +901,6 @@ export interface ApiCommonContentCommonContent extends Schema.CollectionType {
       Attribute.Required &
       Attribute.SetPluginOptions<{
         i18n: {
-          localized: false;
-        };
-      }>;
-    newsletterLabelTextCode: Attribute.JSON &
-      Attribute.CustomField<'plugin::multi-select.multi-select', ['snp']> &
-      Attribute.SetPluginOptions<{
-        i18n: {
           localized: true;
         };
       }>;
@@ -923,7 +916,13 @@ export interface ApiCommonContentCommonContent extends Schema.CollectionType {
       > &
       Attribute.SetPluginOptions<{
         i18n: {
-          localized: true;
+          localized: false;
+        };
+      }>;
+    newsletterLabelTextCode: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
         };
       }>;
     createdAt: Attribute.DateTime;


### PR DESCRIPTION
Because:

- newsletterLabelCodeText should be a string supporting one of the following values. 'mozilla', 'snp', 'hubs', 'mdnplus'

This commit:

- Updates newsletterLabelCodeText to string and removes localization
- Removes localization from newsletterSlug
- Adds localization to successActionButtonUrl

Closes #FXA-10428