### PR TITLE
feat(subplat): Add IAP to content type

### DIFF
--- a/src/api/offering/content-types/offering/schema.json
+++ b/src/api/offering/content-types/offering/schema.json
@@ -86,6 +86,11 @@
       "repeatable": true,
       "component": "stripe.stripe-legacy-plans"
     },
+    "stripeLegacyIapPrices": {
+      "type": "component",
+      "repeatable": true,
+      "component": "stripe.stripe-legacy-iap-prices"
+    },
     "capabilities": {
       "type": "relation",
       "relation": "manyToMany",

--- a/src/api/purchase/content-types/purchase/schema.json
+++ b/src/api/purchase/content-types/purchase/schema.json
@@ -26,6 +26,12 @@
       "repeatable": true,
       "component": "stripe.stripe-plan-choices"
     },
+    "stripeIapPlanChoices": {
+      "displayName": "Stripe IAP Plan Choices",
+      "type": "component",
+      "repeatable": true,
+      "component": "stripe.stripe-iap-plan-choices"
+    },
     "purchaseDetails": {
       "type": "relation",
       "relation": "oneToOne",

--- a/src/components/stripe/stripe-iap-plan-choices.json
+++ b/src/components/stripe/stripe-iap-plan-choices.json
@@ -1,0 +1,14 @@
+{
+  "collectionName": "components_stripe_stripe_iap_plan_choices",
+  "info": {
+    "displayName": "Stripe IAP Plan Choices",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "stripeIapPlanChoice": {
+      "type": "string",
+      "minLength": 2
+    }
+  }
+}

--- a/src/components/stripe/stripe-legacy-iap-prices.json
+++ b/src/components/stripe/stripe-legacy-iap-prices.json
@@ -1,0 +1,14 @@
+{
+  "collectionName": "components_stripe_stripe_legacy_iap_prices",
+  "info": {
+    "displayName": "Stripe Legacy IAP Prices",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "stripeLegacyIapPrice": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -42,6 +42,20 @@ export interface StripeStripeLegacyPlans extends Struct.ComponentSchema {
   };
 }
 
+export interface StripeStripeLegacyIapPrices extends Struct.ComponentSchema {
+  collectionName: 'components_stripe_stripe_legacy_iap_prices';
+  info: {
+    description: '';
+    displayName: 'Stripe Legacy IAP Prices';
+  };
+  attributes: {
+    stripeLegacyIapPrice: Schema.Attribute.String &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+  };
+}
+
 export interface StripeStripePlanChoices extends Struct.ComponentSchema {
   collectionName: 'components_stripe_stripe_plan_choices';
   info: {
@@ -50,6 +64,20 @@ export interface StripeStripePlanChoices extends Struct.ComponentSchema {
   };
   attributes: {
     stripePlanChoice: Schema.Attribute.String &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 2;
+      }>;
+  };
+}
+
+export interface StripeStripeIapPlanChoices extends Struct.ComponentSchema {
+  collectionName: 'components_stripe_stripe_iap_plan_choices';
+  info: {
+    description: '';
+    displayName: 'Stripe IAP Plan Choices';
+  };
+  attributes: {
+    stripeIapPlanChoice: Schema.Attribute.String &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 2;
       }>;
@@ -75,7 +103,9 @@ declare module '@strapi/strapi' {
     export interface ComponentSchemas {
       'iap.apple-product-i-ds': IapAppleProductIDs;
       'iap.google-sk-us': IapGoogleSkUs;
+      'stripe.stripe-iap-plan-choices': StripeStripeIapPlanChoices;
       'stripe.stripe-legacy-plans': StripeStripeLegacyPlans;
+      'stripe.stripe-legacy-iap-prices': StripeStripeLegacyIapPrices;
       'stripe.stripe-plan-choices': StripeStripePlanChoices;
       'stripe.stripe-promo-codes': StripeStripePromoCodes;
     }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -724,6 +724,10 @@ export interface ApiOfferingOffering extends Struct.CollectionTypeSchema {
       'stripe.stripe-legacy-plans',
       true
     >;
+    stripeLegacyIapPrices: Schema.Attribute.Component<
+    'stripe.stripe-legacy-iap-prices',
+    true
+  >;
     stripeProductId: Schema.Attribute.String & Schema.Attribute.Required;
     subGroups: Schema.Attribute.Relation<
       'manyToMany',
@@ -837,6 +841,10 @@ export interface ApiPurchasePurchase extends Struct.CollectionTypeSchema {
       'stripe.stripe-plan-choices',
       true
     >;
+    stripeIapPlanChoices: Schema.Attribute.Component<
+    'stripe.stripe-iap-plan-choices',
+    true
+  >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
## This pull request

- [x] Updates Strapi IAP content type
   - [x] Add stripeLegacyIapPrices (same type of field as offering.stripeLegacyPlans)
   - [x] Add stripeIapPlanChoices (Same type of field as purchase.stripePlanChoices)