### PR TITLE
feat(strapi): update IAP with stripe prices

### DIFF
--- a/src/api/iap/content-types/iap/schema.json
+++ b/src/api/iap/content-types/iap/schema.json
@@ -26,6 +26,16 @@
       "type": "component",
       "repeatable": true,
       "component": "iap.google-sk-us"
+    },
+    "stripeLegacyIapPrices": {
+      "type": "component",
+      "repeatable": true,
+      "component": "iap.stripe-legacy-iap-prices"
+    },
+    "stripePlanChoices": {
+      "type": "component",
+      "repeatable": true,
+      "component": "iap.stripe-plan-choices"
     }
   }
 }

--- a/src/components/iap/stripe-legacy-iap-prices.json
+++ b/src/components/iap/stripe-legacy-iap-prices.json
@@ -1,0 +1,15 @@
+{
+  "collectionName": "components_iap_stripe_legacy_iap_prices",
+  "info": {
+    "displayName": "Stripe Legacy IAP Prices",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "stripeLegacyIapPrices": {
+      "type": "string",
+      "unique": true,
+      "regex": "^(price_|plan_)"
+    }
+  }
+}

--- a/src/components/iap/stripe-plan-choices.json
+++ b/src/components/iap/stripe-plan-choices.json
@@ -1,15 +1,15 @@
 {
-  "collectionName": "components_stripe_stripe_plan_choices",
+  "collectionName": "components_iap_stripe_plan_choices",
   "info": {
     "displayName": "Stripe Plan Choices",
     "description": ""
   },
   "options": {},
   "attributes": {
-    "stripePlanChoice": {
+    "stripePlanChoices": {
       "type": "string",
-      "regex": "^(price_|plan_)",
-      "unique": true
+      "unique": true,
+      "regex": "^(price_|plan_)"
     }
   }
 }

--- a/src/components/stripe/stripe-legacy-plans.json
+++ b/src/components/stripe/stripe-legacy-plans.json
@@ -8,7 +8,8 @@
   "attributes": {
     "stripeLegacyPlan": {
       "type": "string",
-      "minLength": 1
+      "regex": "^(price_|plan_)",
+      "unique": true
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -28,6 +28,28 @@ export interface IapGoogleSkUs extends Struct.ComponentSchema {
   };
 }
 
+export interface IapStripeLegacyIapPrices extends Struct.ComponentSchema {
+  collectionName: 'components_iap_stripe_legacy_iap_prices';
+  info: {
+    description: '';
+    displayName: 'Stripe Legacy IAP Prices';
+  };
+  attributes: {
+    stripeLegacyIapPrices: Schema.Attribute.String & Schema.Attribute.Unique;
+  };
+}
+
+export interface IapStripePlanChoices extends Struct.ComponentSchema {
+  collectionName: 'components_iap_stripe_plan_choices';
+  info: {
+    description: '';
+    displayName: 'Stripe Plan Choices';
+  };
+  attributes: {
+    stripePlanChoices: Schema.Attribute.String & Schema.Attribute.Unique;
+  };
+}
+
 export interface StripeStripeLegacyPlans extends Struct.ComponentSchema {
   collectionName: 'components_stripe_stripe_legacy_plans';
   info: {
@@ -35,10 +57,7 @@ export interface StripeStripeLegacyPlans extends Struct.ComponentSchema {
     displayName: 'Stripe Legacy Plans';
   };
   attributes: {
-    stripeLegacyPlan: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    stripeLegacyPlan: Schema.Attribute.String & Schema.Attribute.Unique;
   };
 }
 
@@ -49,10 +68,7 @@ export interface StripeStripePlanChoices extends Struct.ComponentSchema {
     displayName: 'Stripe Plan Choices';
   };
   attributes: {
-    stripePlanChoice: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 2;
-      }>;
+    stripePlanChoice: Schema.Attribute.String & Schema.Attribute.Unique;
   };
 }
 
@@ -75,6 +91,8 @@ declare module '@strapi/strapi' {
     export interface ComponentSchemas {
       'iap.apple-product-i-ds': IapAppleProductIDs;
       'iap.google-sk-us': IapGoogleSkUs;
+      'iap.stripe-legacy-iap-prices': IapStripeLegacyIapPrices;
+      'iap.stripe-plan-choices': IapStripePlanChoices;
       'stripe.stripe-legacy-plans': StripeStripeLegacyPlans;
       'stripe.stripe-plan-choices': StripeStripePlanChoices;
       'stripe.stripe-promo-codes': StripeStripePromoCodes;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -620,6 +620,14 @@ export interface ApiIapIap extends Struct.CollectionTypeSchema {
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::iap.iap'> &
       Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
+    stripeLegacyIapPrices: Schema.Attribute.Component<
+      'iap.stripe-legacy-iap-prices',
+      true
+    >;
+    stripePlanChoices: Schema.Attribute.Component<
+      'iap.stripe-plan-choices',
+      true
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
Because:

- Need to be able to link a specific offering to a list of Stripe prices

This commit:

- Adds stripeLegacyIapPrices and stripePlanChoices to IAP content type

Closes #FXA-7837