### PR TITLE
fix(strapi): prevent empty entries

### DIFF
--- a/src/components/iap/apple-product-i-ds.json
+++ b/src/components/iap/apple-product-i-ds.json
@@ -8,7 +8,9 @@
   "attributes": {
     "appleProductID": {
       "type": "string",
-      "minLength": 2
+      "minLength": 2,
+      "required": true,
+      "unique": true
     }
   }
 }

--- a/src/components/iap/google-sk-us.json
+++ b/src/components/iap/google-sk-us.json
@@ -8,7 +8,9 @@
   "attributes": {
     "googleSKU": {
       "type": "string",
-      "minLength": 2
+      "minLength": 2,
+      "required": true,
+      "unique": true
     }
   }
 }

--- a/src/components/iap/stripe-legacy-iap-prices.json
+++ b/src/components/iap/stripe-legacy-iap-prices.json
@@ -9,7 +9,8 @@
     "stripeLegacyIapPrices": {
       "type": "string",
       "unique": true,
-      "regex": "^(price_|plan_)"
+      "regex": "^(price_|plan_)",
+      "required": true
     }
   }
 }

--- a/src/components/iap/stripe-plan-choices.json
+++ b/src/components/iap/stripe-plan-choices.json
@@ -9,7 +9,8 @@
     "stripePlanChoices": {
       "type": "string",
       "unique": true,
-      "regex": "^(price_|plan_)"
+      "regex": "^(price_|plan_)",
+      "required": true
     }
   }
 }

--- a/src/components/stripe/stripe-legacy-plans.json
+++ b/src/components/stripe/stripe-legacy-plans.json
@@ -9,7 +9,8 @@
     "stripeLegacyPlan": {
       "type": "string",
       "regex": "^(price_|plan_)",
-      "unique": true
+      "unique": true,
+      "required": true
     }
   }
 }

--- a/src/components/stripe/stripe-plan-choices.json
+++ b/src/components/stripe/stripe-plan-choices.json
@@ -9,7 +9,8 @@
     "stripePlanChoice": {
       "type": "string",
       "regex": "^(price_|plan_)",
-      "unique": true
+      "unique": true,
+      "required": true
     }
   }
 }

--- a/src/components/stripe/stripe-promo-codes.json
+++ b/src/components/stripe/stripe-promo-codes.json
@@ -9,7 +9,8 @@
     "PromoCode": {
       "type": "string",
       "unique": false,
-      "minLength": 2
+      "minLength": 2,
+      "required": true
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -8,6 +8,8 @@ export interface IapAppleProductIDs extends Struct.ComponentSchema {
   };
   attributes: {
     appleProductID: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 2;
       }>;
@@ -22,6 +24,8 @@ export interface IapGoogleSkUs extends Struct.ComponentSchema {
   };
   attributes: {
     googleSKU: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 2;
       }>;
@@ -35,7 +39,9 @@ export interface IapStripeLegacyIapPrices extends Struct.ComponentSchema {
     displayName: 'Stripe Legacy IAP Prices';
   };
   attributes: {
-    stripeLegacyIapPrices: Schema.Attribute.String & Schema.Attribute.Unique;
+    stripeLegacyIapPrices: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
   };
 }
 
@@ -46,7 +52,9 @@ export interface IapStripePlanChoices extends Struct.ComponentSchema {
     displayName: 'Stripe Plan Choices';
   };
   attributes: {
-    stripePlanChoices: Schema.Attribute.String & Schema.Attribute.Unique;
+    stripePlanChoices: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
   };
 }
 
@@ -57,7 +65,9 @@ export interface StripeStripeLegacyPlans extends Struct.ComponentSchema {
     displayName: 'Stripe Legacy Plans';
   };
   attributes: {
-    stripeLegacyPlan: Schema.Attribute.String & Schema.Attribute.Unique;
+    stripeLegacyPlan: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
   };
 }
 
@@ -68,7 +78,9 @@ export interface StripeStripePlanChoices extends Struct.ComponentSchema {
     displayName: 'Stripe Plan Choices';
   };
   attributes: {
-    stripePlanChoice: Schema.Attribute.String & Schema.Attribute.Unique;
+    stripePlanChoice: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
   };
 }
 
@@ -80,6 +92,7 @@ export interface StripeStripePromoCodes extends Struct.ComponentSchema {
   };
   attributes: {
     PromoCode: Schema.Attribute.String &
+      Schema.Attribute.Required &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 2;
       }>;


### PR DESCRIPTION
Because:

- Repeating components currently allow empty entries

This commit:

- By marking the field as required, empty entries are now allowed in a repeating component.

Closes #