### PR TITLE
feat(common content): localize TOS download url

### DIFF
--- a/src/api/common-content/content-types/common-content/schema.json
+++ b/src/api/common-content/content-types/common-content/schema.json
@@ -59,7 +59,7 @@
     "termsOfServiceDownloadUrl": {
       "pluginOptions": {
         "i18n": {
-          "localized": false
+          "localized": true
         }
       },
       "type": "string",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -506,7 +506,7 @@ export interface ApiCommonContentCommonContent
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
-          localized: false;
+          localized: true;
         };
       }>;
     termsOfServiceUrl: Schema.Attribute.String &


### PR DESCRIPTION
Because:

* The TOS download url needs to be different for each locale

This commit:

* updates the common content schema to enable l18n localization on this field

Closes #FXA-11454