### PR TITLE
feat(cms): Add pageTitle to accounts pages

### DIFF
--- a/src/components/accounts/page-config.json
+++ b/src/components/accounts/page-config.json
@@ -19,6 +19,9 @@
     },
     "logoAltText": {
       "type": "string"
+    },
+    "pageTitle": {
+      "type": "string"
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -33,6 +33,7 @@ export interface AccountsPageConfig extends Struct.ComponentSchema {
     headline: Schema.Attribute.String;
     logoAltText: Schema.Attribute.String;
     logoUrl: Schema.Attribute.String;
+    pageTitle: Schema.Attribute.String;
     primaryButtonText: Schema.Attribute.String;
   };
 }


### PR DESCRIPTION
Because:
  * We want to allow the customization of individual Accounts page titles

This Commit:
  * Adds a new pageTitle property to the accounts page-config

Closes: #FXA-12165