### PR TITLE
feat(cms): Add emailLogoWidth for relying party customization

### DIFF
--- a/src/components/accounts/shared.json
+++ b/src/components/accounts/shared.json
@@ -21,6 +21,11 @@
     "emailLogoUrl": {
       "type": "string"
     },
+    "emailLogoWidth": {
+      "type": "string",
+      "default": "280px",
+      "regex": "^[0-9]+px$"
+    },
     "emailLogoAltText": {
       "type": "string"
     },

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -49,6 +49,8 @@ export interface AccountsShared extends Struct.ComponentSchema {
     emailFromName: Schema.Attribute.String;
     emailLogoAltText: Schema.Attribute.String;
     emailLogoUrl: Schema.Attribute.String;
+    emailLogoWidth: Schema.Attribute.String &
+      Schema.Attribute.DefaultTo<'280px'>;
     favicon: Schema.Attribute.String;
     featureFlags: Schema.Attribute.Component<'accounts.feature-flags', false>;
     headerLogoAltText: Schema.Attribute.String;


### PR DESCRIPTION
Because:

* Monitor logo is too small in CMS customized emails

This commit:

* makes customized logos larger by adding an optional field`emailLogoWidth` in strapi, which defaults to 280px.

Closes #FXA-12195