### PR TITLE
chore(cms): Update required Accounts CMS properties

### DIFF
--- a/src/api/relying-party/content-types/relying-party/schema.json
+++ b/src/api/relying-party/content-types/relying-party/schema.json
@@ -24,22 +24,26 @@
     "shared": {
       "type": "component",
       "component": "accounts.shared",
-      "repeatable": false
+      "repeatable": false,
+      "required": true
     },
     "EmailFirstPage": {
       "type": "component",
       "component": "accounts.page-config",
-      "repeatable": false
+      "repeatable": false,
+      "required": true
     },
     "SignupSetPasswordPage": {
       "type": "component",
       "component": "accounts.page-config",
-      "repeatable": false
+      "repeatable": false,
+      "required": true
     },
     "SignupConfirmCodePage": {
       "type": "component",
       "component": "accounts.page-config",
-      "repeatable": false
+      "repeatable": false,
+      "required": true
     },
     "SignupConfirmedSyncPage": {
       "type": "component",
@@ -49,7 +53,8 @@
     "SigninPage": {
       "type": "component",
       "component": "accounts.page-config",
-      "repeatable": false
+      "repeatable": false,
+      "required": true
     },
     "SigninTokenCodePage": {
       "type": "component",

--- a/src/components/accounts/page-config.json
+++ b/src/components/accounts/page-config.json
@@ -6,13 +6,15 @@
   "options": {},
   "attributes": {
     "headline": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "description": {
       "type": "text"
     },
     "primaryButtonText": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "logoUrl": {
       "type": "string"

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -30,11 +30,11 @@ export interface AccountsPageConfig extends Struct.ComponentSchema {
   };
   attributes: {
     description: Schema.Attribute.Text;
-    headline: Schema.Attribute.String;
+    headline: Schema.Attribute.String & Schema.Attribute.Required;
     logoAltText: Schema.Attribute.String;
     logoUrl: Schema.Attribute.String;
     pageTitle: Schema.Attribute.String;
-    primaryButtonText: Schema.Attribute.String;
+    primaryButtonText: Schema.Attribute.String & Schema.Attribute.Required;
   };
 }
 

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -878,7 +878,8 @@ export interface ApiRelyingPartyRelyingParty
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    EmailFirstPage: Schema.Attribute.Component<'accounts.page-config', false>;
+    EmailFirstPage: Schema.Attribute.Component<'accounts.page-config', false> &
+      Schema.Attribute.Required;
     entrypoint: Schema.Attribute.String;
     l10nId: Schema.Attribute.String &
       Schema.Attribute.Required &
@@ -895,8 +896,10 @@ export interface ApiRelyingPartyRelyingParty
       false
     >;
     publishedAt: Schema.Attribute.DateTime;
-    shared: Schema.Attribute.Component<'accounts.shared', false>;
-    SigninPage: Schema.Attribute.Component<'accounts.page-config', false>;
+    shared: Schema.Attribute.Component<'accounts.shared', false> &
+      Schema.Attribute.Required;
+    SigninPage: Schema.Attribute.Component<'accounts.page-config', false> &
+      Schema.Attribute.Required;
     SigninTokenCodePage: Schema.Attribute.Component<
       'accounts.page-config',
       false
@@ -908,7 +911,8 @@ export interface ApiRelyingPartyRelyingParty
     SignupConfirmCodePage: Schema.Attribute.Component<
       'accounts.page-config',
       false
-    >;
+    > &
+      Schema.Attribute.Required;
     SignupConfirmedSyncPage: Schema.Attribute.Component<
       'accounts.page-config',
       false
@@ -916,7 +920,8 @@ export interface ApiRelyingPartyRelyingParty
     SignupSetPasswordPage: Schema.Attribute.Component<
       'accounts.page-config',
       false
-    >;
+    > &
+      Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
Because:
  - We want to clearly indicate what pages and properties are required for serving CMS on FxA

This Commit:
  - Updates description, headline, and primaryButtonText to required on relying-party page config
  - Updates relying-party schema to make some pages required.