### PR TITLE
fix(payments-next): strapi - fields appear linked across locales

### DIFF
--- a/src/api/common-content/content-types/common-content/schema.json
+++ b/src/api/common-content/content-types/common-content/schema.json
@@ -39,7 +39,7 @@
     "privacyNoticeDownloadUrl": {
       "pluginOptions": {
         "i18n": {
-          "localized": false
+          "localized": true
         }
       },
       "type": "string",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -482,7 +482,7 @@ export interface ApiCommonContentCommonContent
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
-          localized: false;
+          localized: true;
         };
       }>;
     privacyNoticeUrl: Schema.Attribute.String &


### PR DESCRIPTION
Because:

* In Common Content, when changing the value in the privacyNoticeDownloadUrl field, the value is also set across all locales for the product. As a result, this field is set so that all locales download the Privacy Notice in English, as it is the fallback language.

This commit:

* Sets privacyNoticeDownloadUrl localized = true

Closes #[PAY-3166](https://mozilla-hub.atlassian.net/browse/PAY-3166)