### PR TITLE
feat(payments-next): Cancellation flow: Update fxa-strapi repo

### DIFF
--- a/src/api/offering/content-types/offering/schema.json
+++ b/src/api/offering/content-types/offering/schema.json
@@ -120,6 +120,12 @@
       "relation": "manyToMany",
       "target": "api::churn-intervention.churn-intervention",
       "mappedBy": "offerings"
+    },
+    "upgrade_interstitial_offers": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::upgrade-interstitial-offer.upgrade-interstitial-offer",
+      "mappedBy": "offering"
     }
   }
 }

--- a/src/api/upgrade-interstitial-offer/content-types/upgrade-interstitial-offer/schema.json
+++ b/src/api/upgrade-interstitial-offer/content-types/upgrade-interstitial-offer/schema.json
@@ -1,0 +1,150 @@
+{
+  "kind": "collectionType",
+  "collectionName": "upgrade_interstitial_offers",
+  "info": {
+    "singularName": "upgrade-interstitial-offer",
+    "pluralName": "upgrade-interstitial-offers",
+    "displayName": "Upgrade Interstitial Offer"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "internalName": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "offeringApiIdentifier": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "currentInterval": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "enumeration",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "halfyearly",
+        "yearly"
+      ],
+      "required": true
+    },
+    "upgradeInterval": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "enumeration",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "halfyearly",
+        "yearly"
+      ],
+      "required": true
+    },
+    "advertisedSavings": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "integer",
+      "required": true
+    },
+    "ctaMessage": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string",
+      "required": true
+    },
+    "modalHeading1": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string",
+      "required": true
+    },
+    "modalHeading2": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "modalMessage": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text",
+      "required": true
+    },
+    "productPageUrl": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "string",
+      "required": true,
+      "regex": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-/]))?$"
+    },
+    "upgradeButtonLabel": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string",
+      "required": true
+    },
+    "upgradeButtonUrl": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "string",
+      "required": true,
+      "regex": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-/]))?$"
+    },
+    "offering": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::offering.offering",
+      "inversedBy": "upgrade_interstitial_offers"
+    }
+  }
+}

--- a/src/api/upgrade-interstitial-offer/controllers/upgrade-interstitial-offer.js
+++ b/src/api/upgrade-interstitial-offer/controllers/upgrade-interstitial-offer.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * upgrade-interstitial-offer controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::upgrade-interstitial-offer.upgrade-interstitial-offer');

--- a/src/api/upgrade-interstitial-offer/routes/upgrade-interstitial-offer.js
+++ b/src/api/upgrade-interstitial-offer/routes/upgrade-interstitial-offer.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * upgrade-interstitial-offer router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::upgrade-interstitial-offer.upgrade-interstitial-offer');

--- a/src/api/upgrade-interstitial-offer/services/upgrade-interstitial-offer.js
+++ b/src/api/upgrade-interstitial-offer/services/upgrade-interstitial-offer.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * upgrade-interstitial-offer service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::upgrade-interstitial-offer.upgrade-interstitial-offer');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -959,6 +959,10 @@ export interface ApiOfferingOffering extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    upgrade_interstitial_offers: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::upgrade-interstitial-offer.upgrade-interstitial-offer'
+    >;
   };
 }
 
@@ -1214,6 +1218,128 @@ export interface ApiSubgroupSubgroup extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+  };
+}
+
+export interface ApiUpgradeInterstitialOfferUpgradeInterstitialOffer
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'upgrade_interstitial_offers';
+  info: {
+    displayName: 'Upgrade Interstitial Offer';
+    pluralName: 'upgrade-interstitial-offers';
+    singularName: 'upgrade-interstitial-offer';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    advertisedSavings: Schema.Attribute.Integer &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    ctaMessage: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    currentInterval: Schema.Attribute.Enumeration<
+      ['daily', 'weekly', 'monthly', 'halfyearly', 'yearly']
+    > &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
+    internalName: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::upgrade-interstitial-offer.upgrade-interstitial-offer'
+    >;
+    modalHeading1: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    modalHeading2: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    modalMessage: Schema.Attribute.Text &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    offering: Schema.Attribute.Relation<'manyToOne', 'api::offering.offering'>;
+    offeringApiIdentifier: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
+    productPageUrl: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    upgradeButtonLabel: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    upgradeButtonUrl: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
+    upgradeInterval: Schema.Attribute.Enumeration<
+      ['daily', 'weekly', 'monthly', 'halfyearly', 'yearly']
+    > &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
   };
 }
 
@@ -1738,6 +1864,7 @@ declare module '@strapi/strapi' {
       'api::relying-party.relying-party': ApiRelyingPartyRelyingParty;
       'api::service.service': ApiServiceService;
       'api::subgroup.subgroup': ApiSubgroupSubgroup;
+      'api::upgrade-interstitial-offer.upgrade-interstitial-offer': ApiUpgradeInterstitialOfferUpgradeInterstitialOffer;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
       'plugin::i18n.locale': PluginI18NLocale;


### PR DESCRIPTION
Because:

* A customer may enter the Cancellation flow for churn intervention when they click the “Cancel subscription” button on Subscription Management, and we want to show them custom Upgrade messaging on the Interstitial Offer page if it exists (if they meet certain criteria).

This commit:

* Adds a new 'Upgrade Interstitial Offer' content type to fxa-strapi repo.

Closes #[PAY-3367](https://mozilla-hub.atlassian.net/browse/PAY-3367)