### PR TITLE
fix(payments-next): Remove uniqueness requirement from offeringApiIdentifier

### DIFF
--- a/src/api/cancel-interstitial-offer/content-types/cancel-interstitial-offer/schema.json
+++ b/src/api/cancel-interstitial-offer/content-types/cancel-interstitial-offer/schema.json
@@ -32,8 +32,7 @@
         }
       },
       "type": "string",
-      "required": true,
-      "unique": true
+      "required": true
     },
     "currentInterval": {
       "pluginOptions": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -432,7 +432,7 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
 
 export interface ApiCancelInterstitialOfferCancelInterstitialOffer
   extends Struct.CollectionTypeSchema {
-  collectionName: 'cancel';
+  collectionName: 'cancel_interstitial_offers';
   info: {
     displayName: 'Cancel Interstitial Offer';
     pluralName: 'cancel-interstitial-offers';
@@ -509,7 +509,6 @@ export interface ApiCancelInterstitialOfferCancelInterstitialOffer
     offering: Schema.Attribute.Relation<'manyToOne', 'api::offering.offering'>;
     offeringApiIdentifier: Schema.Attribute.String &
       Schema.Attribute.Required &
-      Schema.Attribute.Unique &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: false;


### PR DESCRIPTION
Because:

* offeringApiIdentifier doesn't have to be unique

This commit:

* Removes offeringApiIdentifier's requirement to be unique