### PR TITLE
feat(cms): customize relay text

### DIFF
--- a/src/components/accounts/shared.json
+++ b/src/components/accounts/shared.json
@@ -50,6 +50,9 @@
     },
     "favicon": {
       "type": "string"
+    },
+    "additionalAccessibilityInfo": {
+      "type": "string"
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -58,6 +58,7 @@ export interface AccountsShared extends Struct.ComponentSchema {
     displayName: 'Shared';
   };
   attributes: {
+    additionalAccessibilityInfo: Schema.Attribute.String;
     backgrounds: Schema.Attribute.Component<
       'accounts.shared-backgrounds',
       false

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1635,8 +1635,8 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
-    alternativeText: Schema.Attribute.String;
-    caption: Schema.Attribute.String;
+    alternativeText: Schema.Attribute.Text;
+    caption: Schema.Attribute.Text;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1660,7 +1660,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
       Schema.Attribute.Private;
     mime: Schema.Attribute.String & Schema.Attribute.Required;
     name: Schema.Attribute.String & Schema.Attribute.Required;
-    previewUrl: Schema.Attribute.String;
+    previewUrl: Schema.Attribute.Text;
     provider: Schema.Attribute.String & Schema.Attribute.Required;
     provider_metadata: Schema.Attribute.JSON;
     publishedAt: Schema.Attribute.DateTime;
@@ -1669,7 +1669,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    url: Schema.Attribute.String & Schema.Attribute.Required;
+    url: Schema.Attribute.Text & Schema.Attribute.Required;
     width: Schema.Attribute.Integer;
   };
 }


### PR DESCRIPTION
Because:

* we want to customize "Firefox will try sending you back to use an email mask after you sign in." because we need something similar for smart window

This commit:

* adds additionalAccessibilityInfo (name suggested by Ross) to cmsInfo.shared

Closes FXA-12638