### PR TITLE
feat(payments-next): Strapi clean up - remove unused fields

### DIFF
--- a/src/api/cancel-interstitial-offer/content-types/cancel-interstitial-offer/schema.json
+++ b/src/api/cancel-interstitial-offer/content-types/cancel-interstitial-offer/schema.json
@@ -66,24 +66,6 @@
       ],
       "required": true
     },
-    "advertisedSavings": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": false
-        }
-      },
-      "type": "integer",
-      "required": true
-    },
-    "ctaMessage": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "string",
-      "required": true
-    },
     "modalHeading1": {
       "pluginOptions": {
         "i18n": {
@@ -92,14 +74,6 @@
       },
       "type": "string",
       "required": true
-    },
-    "modalHeading2": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "string"
     },
     "modalMessage": {
       "pluginOptions": {

--- a/src/api/churn-intervention/content-types/churn-intervention/schema.json
+++ b/src/api/churn-intervention/content-types/churn-intervention/schema.json
@@ -90,7 +90,7 @@
       },
       "type": "integer",
       "required": true,
-      "min": 0,
+      "min": 1,
       "max": 100
     },
     "ctaMessage": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -447,23 +447,9 @@ export interface ApiCancelInterstitialOfferCancelInterstitialOffer
     };
   };
   attributes: {
-    advertisedSavings: Schema.Attribute.Integer &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: false;
-        };
-      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    ctaMessage: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
     currentInterval: Schema.Attribute.Enumeration<
       ['daily', 'weekly', 'monthly', 'halfyearly', 'yearly']
     > &
@@ -488,12 +474,6 @@ export interface ApiCancelInterstitialOfferCancelInterstitialOffer
     >;
     modalHeading1: Schema.Attribute.String &
       Schema.Attribute.Required &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    modalHeading2: Schema.Attribute.String &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;
@@ -641,7 +621,7 @@ export interface ApiChurnInterventionChurnIntervention
       Schema.Attribute.SetMinMax<
         {
           max: 100;
-          min: 0;
+          min: 1;
         },
         number
       >;


### PR DESCRIPTION
Because:

* We didn't end up using the advertisedSavings, ctaMessage and modalHeading2 fields in Cancel Interstitial Offer.
* For Churn Intervention, the min for discountAmount should be 1 instead of 0

This commit:

* Cleans up the above

Closes #[PAY-3515](https://mozilla-hub.atlassian.net/browse/PAY-3515)

Cancel Interstitial:

<img width="3024" height="1808" alt="image" src="https://github.com/user-attachments/assets/db674992-7b84-476b-921b-e4b379d811bd" />

Churn Intervention discountAmount:
<img width="2972" height="1730" alt="image" src="https://github.com/user-attachments/assets/63e21eba-92db-4d82-be6e-ac95cd912deb" />

