### PR TITLE
feat(2FA): Add 2FA pages to relying-party

### DIFF
--- a/src/api/relying-party/content-types/relying-party/schema.json
+++ b/src/api/relying-party/content-types/relying-party/schema.json
@@ -71,6 +71,26 @@
       "component": "accounts.page-config",
       "repeatable": false
     },
+    "SigninTotpCodePage": {
+      "type": "component",
+      "component": "accounts.page-config",
+      "repeatable": false
+    },
+    "SigninRecoveryChoicePage": {
+      "type": "component",
+      "component": "accounts.page-config",
+      "repeatable": false
+    },
+    "SigninRecoveryCodePage": {
+      "type": "component",
+      "component": "accounts.page-config",
+      "repeatable": false
+    },
+    "SigninRecoveryPhonePage": {
+      "type": "component",
+      "component": "accounts.page-config",
+      "repeatable": false
+    },
     "NewDeviceLoginEmail": {
       "type": "component",
       "component": "accounts.email-config",

--- a/src/components/accounts/page-config.json
+++ b/src/components/accounts/page-config.json
@@ -6,15 +6,13 @@
   "options": {},
   "attributes": {
     "headline": {
-      "type": "string",
-      "required": true
+      "type": "string"
     },
     "description": {
       "type": "text"
     },
     "primaryButtonText": {
-      "type": "string",
-      "required": true
+      "type": "string"
     },
     "logoUrl": {
       "type": "string"


### PR DESCRIPTION
This adds 2FA pages and makes the headline/primary CTA optional. Corresponding FxA PR here: fxa/pull/20136