### PR TITLE
fix: Update internalName for Cancel Interstitial Offer

### DIFF
--- a/src/api/cancel-interstitial-offer/content-types/cancel-interstitial-offer/schema.json
+++ b/src/api/cancel-interstitial-offer/content-types/cancel-interstitial-offer/schema.json
@@ -18,7 +18,7 @@
     "internalName": {
       "pluginOptions": {
         "i18n": {
-          "localized": false
+          "localized": true
         }
       },
       "type": "string",


### PR DESCRIPTION
### Because

Each locale's value for internalName is saved over when a new set of content is created

### This pull request

Updates `localized` to true