### PR TITLE
feat(fxa): Add new 'default' content-type, add PostVerifySetPassword page to RP collections

### DIFF
--- a/src/api/default/content-types/default/schema.json
+++ b/src/api/default/content-types/default/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "singleType",
+  "collectionName": "defaults",
+  "info": {
+    "singularName": "default",
+    "pluralName": "defaults",
+    "displayName": "FxA default (no RP)",
+    "description": "Global, non-RP-keyed content shown on web-integration page. Add fields here for any override that should apply when there is no relying party clientId/entrypoint.",
+    "mainField": "internalName"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "internalName": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "string",
+      "required": true,
+      "default": "Default: only affects flows going to Settings"
+    },
+    "promoQrImageUrl": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string",
+      "regex": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-/]))?$"
+    }
+  }
+}

--- a/src/api/default/controllers/default.js
+++ b/src/api/default/controllers/default.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * default controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::default.default');

--- a/src/api/default/routes/default.js
+++ b/src/api/default/routes/default.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * default router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::default.default');

--- a/src/api/default/services/default.js
+++ b/src/api/default/services/default.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * default service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::default.default');

--- a/src/api/relying-party/content-types/relying-party/schema.json
+++ b/src/api/relying-party/content-types/relying-party/schema.json
@@ -101,6 +101,11 @@
       "component": "accounts.page-config",
       "repeatable": false
     },
+    "PostVerifySetPasswordPage": {
+      "type": "component",
+      "component": "accounts.page-config",
+      "repeatable": false
+    },
     "NewDeviceLoginEmail": {
       "type": "component",
       "component": "accounts.email-config",

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -23,6 +23,23 @@ export interface AccountsFeatureFlags extends Struct.ComponentSchema {
   };
 }
 
+export interface AccountsIllustrationsTheme extends Struct.ComponentSchema {
+  collectionName: 'components_accounts_illustrations_themes';
+  info: {
+    displayName: 'Illustrations Theme';
+  };
+  attributes: {
+    accentBg: Schema.Attribute.String;
+    accentFg: Schema.Attribute.String;
+    cloudPrimary: Schema.Attribute.String;
+    cloudShadow: Schema.Attribute.String;
+    hideClouds: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    primary: Schema.Attribute.String;
+    primaryAlt: Schema.Attribute.String;
+    secondary: Schema.Attribute.String;
+  };
+}
+
 export interface AccountsImage extends Struct.ComponentSchema {
   collectionName: 'components_accounts_images';
   info: {
@@ -41,11 +58,11 @@ export interface AccountsPageConfig extends Struct.ComponentSchema {
   };
   attributes: {
     description: Schema.Attribute.Text;
-    headline: Schema.Attribute.String & Schema.Attribute.Required;
+    headline: Schema.Attribute.String;
     logoAltText: Schema.Attribute.String;
     logoUrl: Schema.Attribute.String;
     pageTitle: Schema.Attribute.String;
-    primaryButtonText: Schema.Attribute.String & Schema.Attribute.Required;
+    primaryButtonText: Schema.Attribute.String;
     primaryImage: Schema.Attribute.Component<'accounts.image', false>;
     splitLayout: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
   };
@@ -78,6 +95,10 @@ export interface AccountsShared extends Struct.ComponentSchema {
     > &
       Schema.Attribute.DefaultTo<'default'>;
     headlineTextColor: Schema.Attribute.String;
+    illustrationsTheme: Schema.Attribute.Component<
+      'accounts.illustrations-theme',
+      false
+    >;
     logoAltText: Schema.Attribute.String;
     logoUrl: Schema.Attribute.String;
     pageTitle: Schema.Attribute.String;
@@ -221,6 +242,7 @@ declare module '@strapi/strapi' {
     export interface ComponentSchemas {
       'accounts.email-config': AccountsEmailConfig;
       'accounts.feature-flags': AccountsFeatureFlags;
+      'accounts.illustrations-theme': AccountsIllustrationsTheme;
       'accounts.image': AccountsImage;
       'accounts.page-config': AccountsPageConfig;
       'accounts.shared': AccountsShared;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -464,7 +464,7 @@ export interface ApiCancelInterstitialOfferCancelInterstitialOffer
       Schema.Attribute.Unique &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
-          localized: false;
+          localized: true;
         };
       }>;
     locale: Schema.Attribute.String;
@@ -909,6 +909,53 @@ export interface ApiCouponConfigCouponConfig
       'stripe.stripe-promo-codes',
       true
     >;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiDefaultDefault extends Struct.SingleTypeSchema {
+  collectionName: 'defaults';
+  info: {
+    description: 'Global, non-RP-keyed content shown on web-integration pages. Add fields here for any override that should apply when there is no relying party clientId/entrypoint.';
+    displayName: 'FxA default (no RP)';
+    mainField: 'internalName';
+    pluralName: 'defaults';
+    singularName: 'default';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    internalName: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }> &
+      Schema.Attribute.DefaultTo<'Default: only affects flows going to Settings'>;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::default.default'
+    >;
+    promoQrImageUrl: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1361,6 +1408,10 @@ export interface ApiRelyingPartyRelyingParty
       'accounts.email-config',
       false
     >;
+    PostVerifySetPasswordPage: Schema.Attribute.Component<
+      'accounts.page-config',
+      false
+    >;
     publishedAt: Schema.Attribute.DateTime;
     shared: Schema.Attribute.Component<'accounts.shared', false> &
       Schema.Attribute.Required;
@@ -1371,7 +1422,23 @@ export interface ApiRelyingPartyRelyingParty
       'accounts.page-config',
       false
     >;
+    SigninRecoveryChoicePage: Schema.Attribute.Component<
+      'accounts.page-config',
+      false
+    >;
+    SigninRecoveryCodePage: Schema.Attribute.Component<
+      'accounts.page-config',
+      false
+    >;
+    SigninRecoveryPhonePage: Schema.Attribute.Component<
+      'accounts.page-config',
+      false
+    >;
     SigninTokenCodePage: Schema.Attribute.Component<
+      'accounts.page-config',
+      false
+    >;
+    SigninTotpCodePage: Schema.Attribute.Component<
       'accounts.page-config',
       false
     >;
@@ -1748,7 +1815,6 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
     ext: Schema.Attribute.String;
-    focalPoint: Schema.Attribute.JSON;
     folder: Schema.Attribute.Relation<'manyToOne', 'plugin::upload.folder'> &
       Schema.Attribute.Private;
     folderPath: Schema.Attribute.String &
@@ -2001,6 +2067,7 @@ declare module '@strapi/strapi' {
       'api::churn-intervention.churn-intervention': ApiChurnInterventionChurnIntervention;
       'api::common-content.common-content': ApiCommonContentCommonContent;
       'api::coupon-config.coupon-config': ApiCouponConfigCouponConfig;
+      'api::default.default': ApiDefaultDefault;
       'api::free-trial.free-trial': ApiFreeTrialFreeTrial;
       'api::iap.iap': ApiIapIap;
       'api::legal-notice.legal-notice': ApiLegalNoticeLegalNotice;


### PR DESCRIPTION
the other side of mozilla/fxa/pull/20405

Looks like this contains some things not merged in yet?