### PR TITLE
feat(payments-next): Add meter content type in Strapi

### DIFF
--- a/src/api/meter/content-types/meter/schema.json
+++ b/src/api/meter/content-types/meter/schema.json
@@ -1,0 +1,48 @@
+{
+  "kind": "collectionType",
+  "collectionName": "meters",
+  "info": {
+    "singularName": "meter",
+    "pluralName": "meters",
+    "displayName": "Meter"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "slug": {
+      "type": "string",
+      "required": true,
+      "unique": true,
+      "regex": "^[a-z0-9]+([_-][a-z0-9]+)*$"
+    },
+    "unit": {
+      "type": "string",
+      "required": true
+    },
+    "limit": {
+      "type": "integer",
+      "required": true
+    },
+    "window": {
+      "type": "enumeration",
+      "required": true,
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "notificationThresholds": {
+      "type": "text",
+      "required": true
+    },
+    "webhooks": {
+      "type": "component",
+      "component": "entitlements.webhooks",
+      "repeatable": true,
+      "required": true
+    }
+  }
+}

--- a/src/api/meter/controllers/meter.js
+++ b/src/api/meter/controllers/meter.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * meter controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::meter.meter');

--- a/src/api/meter/routes/meter.js
+++ b/src/api/meter/routes/meter.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * meter router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::meter.meter');

--- a/src/api/meter/services/meter.js
+++ b/src/api/meter/services/meter.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * meter service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::meter.meter');

--- a/src/components/entitlements/webhooks.json
+++ b/src/components/entitlements/webhooks.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_entitlements_webhooks",
+  "info": {
+    "displayName": "Webhooks"
+  },
+  "options": {},
+  "attributes": {
+    "url": {
+      "type": "string",
+      "required": true,
+      "regex": "^https:\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-/]))?$"
+    },
+    "signingClientId": {
+      "type": "string",
+      "required": true
+    }
+  },
+  "config": {}
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -138,6 +138,17 @@ export interface AccountsTosAndPrivacyNoticeDetails
   };
 }
 
+export interface EntitlementsWebhooks extends Struct.ComponentSchema {
+  collectionName: 'components_entitlements_webhooks';
+  info: {
+    displayName: 'Webhooks';
+  };
+  attributes: {
+    signingClientId: Schema.Attribute.String & Schema.Attribute.Required;
+    url: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
 export interface IapAppleProductIDs extends Struct.ComponentSchema {
   collectionName: 'components_iap_apple_product_i_ds';
   info: {
@@ -248,6 +259,7 @@ declare module '@strapi/strapi' {
       'accounts.shared': AccountsShared;
       'accounts.shared-backgrounds': AccountsSharedBackgrounds;
       'accounts.tos-and-privacy-notice-details': AccountsTosAndPrivacyNoticeDetails;
+      'entitlements.webhooks': EntitlementsWebhooks;
       'iap.apple-product-i-ds': IapAppleProductIDs;
       'iap.google-sk-us': IapGoogleSkUs;
       'iap.stripe-legacy-iap-prices': IapStripeLegacyIapPrices;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -26,6 +26,11 @@ export interface AdminApiToken extends Struct.CollectionTypeSchema {
       Schema.Attribute.SetMinMaxLength<{
         minLength: 1;
       }>;
+    adminPermissions: Schema.Attribute.Relation<
+      'oneToMany',
+      'admin::permission'
+    >;
+    adminUserOwner: Schema.Attribute.Relation<'manyToOne', 'admin::user'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -39,6 +44,9 @@ export interface AdminApiToken extends Struct.CollectionTypeSchema {
         minLength: 1;
       }>;
     expiresAt: Schema.Attribute.DateTime;
+    kind: Schema.Attribute.Enumeration<['content-api', 'admin']> &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'content-api'>;
     lastUsedAt: Schema.Attribute.DateTime;
     lifespan: Schema.Attribute.BigInteger;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
@@ -56,7 +64,6 @@ export interface AdminApiToken extends Struct.CollectionTypeSchema {
     >;
     publishedAt: Schema.Attribute.DateTime;
     type: Schema.Attribute.Enumeration<['read-only', 'full-access', 'custom']> &
-      Schema.Attribute.Required &
       Schema.Attribute.DefaultTo<'read-only'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
@@ -134,6 +141,7 @@ export interface AdminPermission extends Struct.CollectionTypeSchema {
         minLength: 1;
       }>;
     actionParameters: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
+    apiToken: Schema.Attribute.Relation<'manyToOne', 'admin::api-token'>;
     conditions: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<[]>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
@@ -385,6 +393,8 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
+    apiTokens: Schema.Attribute.Relation<'oneToMany', 'admin::api-token'> &
+      Schema.Attribute.Private;
     blocked: Schema.Attribute.Boolean &
       Schema.Attribute.Private &
       Schema.Attribute.DefaultTo<false>;
@@ -918,7 +928,7 @@ export interface ApiCouponConfigCouponConfig
 export interface ApiDefaultDefault extends Struct.SingleTypeSchema {
   collectionName: 'defaults';
   info: {
-    description: 'Global, non-RP-keyed content shown on web-integration pages. Add fields here for any override that should apply when there is no relying party clientId/entrypoint.';
+    description: 'Global, non-RP-keyed content shown on web-integration page. Add fields here for any override that should apply when there is no relying party clientId/entrypoint.';
     displayName: 'FxA default (no RP)';
     mainField: 'internalName';
     pluralName: 'defaults';
@@ -1135,6 +1145,40 @@ export interface ApiLegalNoticeLegalNotice extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+  };
+}
+
+export interface ApiMeterMeter extends Struct.CollectionTypeSchema {
+  collectionName: 'meters';
+  info: {
+    displayName: 'Meter';
+    pluralName: 'meters';
+    singularName: 'meter';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    limit: Schema.Attribute.Integer & Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::meter.meter'> &
+      Schema.Attribute.Private;
+    notificationThresholds: Schema.Attribute.Text & Schema.Attribute.Required;
+    publishedAt: Schema.Attribute.DateTime;
+    slug: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    unit: Schema.Attribute.String & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    webhooks: Schema.Attribute.Component<'entitlements.webhooks', true> &
+      Schema.Attribute.Required;
+    window: Schema.Attribute.Enumeration<['daily', 'weekly', 'monthly']> &
+      Schema.Attribute.Required;
   };
 }
 
@@ -1381,6 +1425,7 @@ export interface ApiRelyingPartyRelyingParty
     draftAndPublish: true;
   };
   attributes: {
+    AuthorizePage: Schema.Attribute.Component<'accounts.page-config', false>;
     clientId: Schema.Attribute.String;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
@@ -1815,6 +1860,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
     ext: Schema.Attribute.String;
+    focalPoint: Schema.Attribute.JSON;
     folder: Schema.Attribute.Relation<'manyToOne', 'plugin::upload.folder'> &
       Schema.Attribute.Private;
     folderPath: Schema.Attribute.String &
@@ -2071,6 +2117,7 @@ declare module '@strapi/strapi' {
       'api::free-trial.free-trial': ApiFreeTrialFreeTrial;
       'api::iap.iap': ApiIapIap;
       'api::legal-notice.legal-notice': ApiLegalNoticeLegalNotice;
+      'api::meter.meter': ApiMeterMeter;
       'api::offering.offering': ApiOfferingOffering;
       'api::purchase-detail.purchase-detail': ApiPurchaseDetailPurchaseDetail;
       'api::purchase.purchase': ApiPurchasePurchase;


### PR DESCRIPTION
This commit:

Adds a meter collection type with:
* slug (string, unique): stable identifier carried on ingest events. Lowercase alphanumeric with optional hyphens or underscores. Examples: tokens_total, images-generated.

* unit (string): free-form human-readable unit, e.g. tokens, bytes, requests.

* limit (number): per-user cap for the current window.
     * I put this as integer - should it be that, or biginteger?

* window (enum): one of daily, weekly, monthly.

* notificationThresholds (number[]): percentages of limit at which to fire a webhook. Following a similar pattern to  the Purchase Details details field, stored as one percentage per line.
     * Update: changed to CSVs instead of newline separated.

* webhooks ({ url, signingClientId }[]): https URLs to POST to when a threshold is met, paired with the clientId whose secret signs that delivery.
     * Using components, following the pattern of Accounts' PageConfig primaryImage. Please let me know if the intention was something else. 

Closes #[ENT-16](https://mozilla-hub.atlassian.net/browse/ENT-16)

<img width="1904" height="863" alt="image" src="https://github.com/user-attachments/assets/6618db8e-e364-4579-8a64-25bdfdafc26d" />

<img width="1163" height="750" alt="image" src="https://github.com/user-attachments/assets/52a91bf4-992c-4ab8-a723-21d61490b51c" />


