### PR TITLE
fix(meter): Update Meter schema

### DIFF
--- a/src/api/meter/content-types/meter/schema.json
+++ b/src/api/meter/content-types/meter/schema.json
@@ -22,7 +22,7 @@
       "required": true
     },
     "limit": {
-      "type": "integer",
+      "type": "biginteger",
       "required": true
     },
     "window": {
@@ -35,14 +35,12 @@
       ]
     },
     "notificationThresholds": {
-      "type": "text",
-      "required": true
+      "type": "text"
     },
     "webhooks": {
       "type": "component",
       "component": "entitlements.webhooks",
-      "repeatable": true,
-      "required": true
+      "repeatable": true
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1162,11 +1162,11 @@ export interface ApiMeterMeter extends Struct.CollectionTypeSchema {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    limit: Schema.Attribute.Integer & Schema.Attribute.Required;
+    limit: Schema.Attribute.BigInteger & Schema.Attribute.Required;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::meter.meter'> &
       Schema.Attribute.Private;
-    notificationThresholds: Schema.Attribute.Text & Schema.Attribute.Required;
+    notificationThresholds: Schema.Attribute.Text;
     publishedAt: Schema.Attribute.DateTime;
     slug: Schema.Attribute.String &
       Schema.Attribute.Required &
@@ -1175,8 +1175,7 @@ export interface ApiMeterMeter extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    webhooks: Schema.Attribute.Component<'entitlements.webhooks', true> &
-      Schema.Attribute.Required;
+    webhooks: Schema.Attribute.Component<'entitlements.webhooks', true>;
     window: Schema.Attribute.Enumeration<['daily', 'weekly', 'monthly']> &
       Schema.Attribute.Required;
   };


### PR DESCRIPTION
This pull request

- Updates schema for Meter:
  - [x] Revises limit's `type` to `biginteger`
  - [x] Removes required for notificationThresholds and webhooks 